### PR TITLE
Improve README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ and openSUSE documentation repositories.
 Currently, setting up this repository means that the following checks
 will be run automatically:
 
-* XML validation with DAPS (using GeekoDoc for DocBook 5 content)
+* XML validation with DAPS (using `Geekodoc <https://github.com/openSUSE/geekodoc>`_ for DocBook 5 content)
 * Check for missing images
 
 Additionally, you can use Travis CI to push live builds to susedoc.github.io.
@@ -74,7 +74,7 @@ Use the following final steps:
     ``DC-*-all``. If none exist, it will use the pattern ``DC-*`` instead. To
     set up any other set of DC files to check, add a file named ``.travis-check-docs``
     to your repo. In this file, list the names of all DC files to check, separated by
-    newlines (``\n``)
+    newlines (``\n``) or spaces.
 
 4. Push the feature branch with:
 
@@ -96,10 +96,10 @@ Concept
 We want to publish HTML builds of our public repositories on https://susedoc.github.io.
 To build the documentation, we are using Travis CI which is already triggered
 for each commit. Our default Travis CI script receives an environment variable from
-the .travis.yml file with all branches that should be published. If the commit, that
+the ``.travis.yml`` file with all branches that should be published. If the commit, that
 Travis is currently validating, belongs to one of those branches, a build will
 be triggered. Travis then needs to push the builds to the target repositories in
-the SUSEdoc organization. For that, each target repository has a SSH public key
+the SUSEDoc organization. For that, each target repository has a SSH public key
 with write access that is used by Travis. The SSH private key is stored in
 the corresponding source repository in an encrypted file. Travis uses an internal
 private key to decrypt this SSH private key.
@@ -122,13 +122,13 @@ CI as described in the previous section. Then follow this procedure:
 
       .. code::
 
-         > ssh-keygen -t rsa -b 4096 -C "doc-team@suse.com" -f id_rsa
+         $ ssh-keygen -t rsa -b 4096 -C "doc-team@suse.com" -f id_rsa
 
    b. Create a secret that will be used to encrypt the SSH private key:
 
       .. code::
 
-         > echo $(openssl rand -base64 64 | tr -d '\n') > secret
+         $ echo $(openssl rand -base64 64 | tr -d '\n') > secret
 
       Store the SSH key and also the secret in the internal doc-dotfiles
       repository.
@@ -138,11 +138,11 @@ CI as described in the previous section. Then follow this procedure:
 
       .. code::
 
-         > openssl aes-256-cbc -pass "file:./secret" -in ./id_rsa -out ./ssh_key.enc -a
-         > cp ssh_key.enc /PATH/TO/XML/REPO/ssh_key.enc
-         > cat secret
+         $ openssl aes-256-cbc -pass "file:./secret" -in ./id_rsa -out ./ssh_key.enc -a
+         $ cp ssh_key.enc /PATH/TO/XML/REPO/ssh_key.enc
+         $ cat secret
 
-      Copy and paste the string from the secret file, you will need it for
+      Copy and paste the string from the secret file. You will need it for
       the next step.
 
    d. We now crate an environment variable named
@@ -151,9 +151,9 @@ CI as described in the previous section. Then follow this procedure:
 
       .. code::
 
-         > travis.ruby2.1 encrypt -r SUSE/doc-repo ENCRYPTED_PRIVKEY_SECRET=INSERT_SECRET_STRING
+         $ travis.ruby2.1 encrypt -r SUSE/doc-repo ENCRYPTED_PRIVKEY_SECRET=INSERT_SECRET_STRING
 
-      Take the result and in the .travis.yml replace the string
+      Take the result and in the ``.travis.yml`` replace the string
       ADD_ENCRYPTED_SECRET with the result. Do not copy the quotes from
       the result.
 
@@ -169,15 +169,15 @@ CI as described in the previous section. Then follow this procedure:
       allows encrypting arbitrary data with the public key over it's
       API.
 
-3. Create a repository in the SUSEdoc organization and add the SSH public
+3. Create a repository in the SUSEDoc organization and add the SSH public
    key as a deployment key.
 
-4. Create a file named .travis-build-docs in the root directory of your
+4. Create a file named ``.travis-build-docs`` in the root directory of your
    repository and add all DC files that should be build. Use one line
-   per DC file.
+   per DC file or separate them by one or more spaces.
 
 5. Add links to the builds to the index.html of the
-   SUSEdoc/susedoc.github.io repository.
+   ``SUSEdoc/susedoc.github.io`` repository.
 
 Docker Image susedoc/ci
 =======================
@@ -187,17 +187,17 @@ Building Docker Image for hub.docker.com
 
 1. Get openSUSE Leap base image from https://github.com/openSUSE/docker-containers-build/tree/openSUSE-Leap-42.3/x86_64
 
-2. Get Dockerfile from doc-ci repo: https://github.com/openSUSE/doc-ci/raw/develop/build-docker-ci/Dockerfile
+2. Get ``Dockerfile`` from doc-ci repo: https://github.com/openSUSE/doc-ci/raw/develop/build-docker-ci/Dockerfile
 
 3. Place both files into one folder and run
 
    .. code::
 
-      > docker build ./
+      $ docker build ./
 
 4. Tag the image and upload it
 
    .. code::
 
-      > docker tag IMAGE_ID susedoc/ci:openSUSE-42.3
-      > docker push susedoc/ci:openSUSE-42.3
+      $ docker tag IMAGE_ID susedoc/ci:openSUSE-42.3
+      $ docker push susedoc/ci:openSUSE-42.3

--- a/README.rst
+++ b/README.rst
@@ -21,54 +21,71 @@ For details, see https://github.com/openSUSE/doc-ci#travis-draft-builds
 Enabling Travis for Doc Repositories
 ====================================
 
-If you want doc repos to be checked with Travis, do the following:
+If you want doc repos to be checked with Travis, follow the steps in the
+following sub sections.
 
-1. On the Travis Web UI:
 
-   a. Open https://travis-ci.org/profile/SUSE and search for your repository.
-      If you cannot find it, click the "Sync account" button on the upper right
-      corner.
+.. _sec-activate-travis:
+Activating Travis Web UI
+------------------------
 
-   b. Enable the doc repo in Travis.
+Before you can use Travis, you need to activate the respective
+repository on our SUSE page:
 
-2. On the GitHub Web UI:
+1. Open https://travis-ci.org/profile/SUSE and search for your repository.
+   If you cannot find it, click the "Sync account" button on the upper right
+   corner.
 
-   a. Open your repo's "Settings" page.
+2. Enable the doc repo in Travis.
 
-   b. Under "Integrations & services", choose "Add service" > "Travis CI"
-  
-   c. Click "Add service"
 
-3. In your documentation repo:
+.. _sec-configure-github:
+Configuring the GitHub Web UI
+-----------------------------
 
-   a. In your doc repo, create a feature branch (for example, ``feature/travis``):
+Enable the Travis service in GitHub as follows:
 
-      .. code::
+1. Open your repo's "Settings" page.
 
-        $ git checkout -b feature/travis
+2. Under "Integrations & services", choose "Add service" > "Travis CI"
 
-   b. Copy the following files from this repo into your doc repo:
+3. Click "Add service"
 
-      * ``travis/template/.travis.yml`` - The main setup file for Travis
-      * ``travis/template/Dockerfile`` - The main setup file for the openSUSE Docker container
-      * ``.dockerignore`` - Files in your repo that should be ignored by Docker
 
-   c. [Optional] By default, Travis will run over DC files matching the pattern
-      ``DC-*-all``. If none exist, it will use the pattern ``DC-*`` instead. To
-      set up any other set of DC files to check, add a file named ``.travis-check-docs``
-      to your repo. In this file, list the names of all DC files to check, separated by
-      newlines (``\n``)
+.. _sec-configure-docrepos:
+Configuring the Documentation Repository
+----------------------------------------
 
-   c. Push the feature branch with:
+Use the following final steps:
 
-      .. code::
+1. In your doc repo, create a feature branch (for example, ``feature/travis``):
 
-          $ git push --set-upstream origin feature/travis
+    .. code::
 
-   d. Wait and see for the results. If you encounter an issue, contact
-      `@tomschr <https://github.com/tomschr/>`_ or `@svenseeberg <https://github.com/svenseeberg/>`_.
+    $ git checkout -b feature/travis
 
-   e. Merge your branch into ``develop``.
+2. Copy the following files from this repo into your doc repo:
+
+    * ``travis/template/.travis.yml`` - The main setup file for Travis
+    * ``travis/template/Dockerfile`` - The main setup file for the openSUSE Docker container
+    * ``.dockerignore`` - Files in your repo that should be ignored by Docker
+
+3. [Optional] By default, Travis will run over DC files matching the pattern
+    ``DC-*-all``. If none exist, it will use the pattern ``DC-*`` instead. To
+    set up any other set of DC files to check, add a file named ``.travis-check-docs``
+    to your repo. In this file, list the names of all DC files to check, separated by
+    newlines (``\n``)
+
+4. Push the feature branch with:
+
+    .. code::
+
+        $ git push --set-upstream origin feature/travis
+
+5. Wait and see for the results. If you encounter an issue, contact
+    `@tomschr <https://github.com/tomschr/>`_ or `@svenseeberg <https://github.com/svenseeberg/>`_.
+
+6. Merge your branch into ``develop``.
 
 
 Travis Draft Builds


### PR DESCRIPTION
@svenseeberg This PR contains the following changes:

* Use subsections to make it more readable
* Improve text:
  * Use double backticks for file names (like .travis.yml)
  * Make shell prompt consistent
  * SUSEdoc -> SUSEDoc
  * Clarified `.travis-build-docs`: spaces are also allowed

---

Apart from that, IMHO could you explain where you get this `travis.ruby2.1` ruby script (is there a link available to just `travis`?)