### PR TITLE
Change default of xml-schema to geekodoc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Name | Required? | Type | Default | Explanation
 `validate-ids` | no | bool | "true" | Enable check whether all referenced `xml:id`s adhere to the character set `[a-z0-9-]` (`daps validate --validate-ids`).
 `validate-images` | no | bool | "true" | Enable check whether all referenced images exist (`daps validate --validate-images`).
 `validate-tables` | no | bool | "true" | Enable check whether all tables within the document are valid (`daps/libexec/validate-tables.py`).
-`xml-schema` | no | string | "geekodoc1" | XML schema to use for DocBook 5-based documents (`geekodoc1`, `geekodoc2`, `docbook51`, `docbook52`).
+`xml-schema` | no | string | "geekodoc2" | Schema file to use for DocBook 5-based documents (`geekodoc1`, `geekodoc2`, `docbook51`, `docbook52`).
 
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,9 @@ inputs:
     default: true
 
   xml-schema:
-    description: "XML schema to use for validation ('geekodoc1', 'geekodoc2', 'docbook51', 'docbook52'). DC file options take precedence over this setting."
+    description: "Schema file to use for validation ('geekodoc1', 'geekodoc2', 'docbook51', 'docbook52'). DC file options take precedence over this setting."
     required: false
-    default: "geekodoc1"
+    default: "geekodoc2"
 
 outputs:
   exit-validate:


### PR DESCRIPTION
Only older products use GeekoDoc v1. We should use GeekoDoc v2 as far as possible.

https://confluence.suse.com/display/documentation/Documentation+repositories

* SUSE/doc-sle: :ok: 
* SUSE/doc-sleha: :ok: 
* SUSE/doc-hpc: :ok: 
* SUSE/doc-slert: :ok: 
* SUSE/doc-slesforsap: :ok: 
* SUSE/doc-ses: :ok: 
* SUSE/doc-vmdp: :ok: 
* SUSE/suse-best-practices: :question: 
* SUSE/doc-public-cloude: :ok: 
* SUSE/technical-reference-documentation: :question: 
* SUSE/doc-liberty: :ok: 
* SUSE/doc-unversioned: :ok: 