### PR TITLE
Fix #51: Replace ::set-output for gha-validate

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -177,7 +177,7 @@ for dc in $dcs; do
 done
 
 
-echo "::set-output name=exit-validate::$exitcode"
+echo "exit-validate=$exitcode" >> $GITHUB_OUTPUT
 if [[ "$exitcode" -gt 0 ]]; then
   fail "Overall validation result of this run ($dcs): failed."
 else


### PR DESCRIPTION
Replaces `::set-output` with >> $GITHUB_OUTPUT

Fix DOCTEAM-784