### PR TITLE
Add ignore-files parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Name | Required? | Type | Default | Explanation
 `mode` | yes | string | "" | Whether to check DC file soundness ('soundness'), select DC files for validation ('list-validate'), or select DC files for building ('list-build').
 `merge-runs` | no | string | "true" | _`mode=list-validate`/`mode=list-build` only:_ If there are more than 8 build/validate runs, run multiple runs in same runner to avoid incurring a container image download each time.
 `original-org` | no | string | "" | _`mode=list-build` only:_ The GitHub org name of the original repo. Builds can usually only be uploaded from within the original repo, not forks. This parameter will disable builds for forked repos.
-
+`ignore-files` | no | array | "" | An array of DC files to ignore. You can use literal values or glob patterns
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "For 'use-case=list-build': The GitHub org name of the original repo. Builds can usually only be uploaded from within the original repo, not forks. This parameter will disable builds for forked repos."
     required: false
     default: ''
+  ignore-files:
+    description: "An array of DC files to ignore. You can use literal values or glob patterns"
+    required: false
+    default: ''
 
 outputs:
   dc-list:
@@ -31,3 +35,4 @@ runs:
     - mode=${{ inputs.mode }}
     - merge-runs=${{ inputs.merge-runs }}
     - original-org=${{ inputs.original-org }}
+    - ignore-files=${{ inputs.ignore-files }}

--- a/select-dcs.sh
+++ b/select-dcs.sh
@@ -68,6 +68,7 @@ mergeruns='true'
 # image downloads/inits which tends to take 1 minute each time currently.
 mergerun_threshold=8
 original_org=''
+ignore_files=''
 
 allow_build='true'
 
@@ -85,6 +86,10 @@ while [[ $1 ]]; do
       original_org=$(echo "$1" | cut -f2- -d'=')
       shift
       ;;
+    ignore-files=*)
+      ignore_files=$(echo "$1" | cut -f2- -d'=')
+      shift
+      ;;
     --)
       shift
       break
@@ -96,6 +101,12 @@ while [[ $1 ]]; do
   esac
 done
 
+log + "  mode=$usecase"
+log + "  mergeruns=$mergeruns"
+log + "  original_org=$original_org"
+log + "  ignore_files=$ignore_files"
+
+
 dc_list=''
 
 # find all dirs that contain DC files
@@ -104,6 +115,7 @@ gha_fold "Checking which directories contain DC files"
   log "DC files in:"
   echo -e "$dc_dirs"
 gha_fold --
+
 
 # USE CASE 1
 if [[ "$usecase" = 'soundness' ]]; then
@@ -293,6 +305,9 @@ elif [[ "$usecase" = 'list-build' ]]; then
 else
   fail "Use case \"$usecase\" is unknown."
 fi
+
+log + "  dc-dirs=$dc_dirs"
+log + "  unsounddc=$unsounddc"
 
 
 # Create a JSON of jobs, optimize for 8 runners (with 8 = $mergerun_threshold)

--- a/select-dcs.sh
+++ b/select-dcs.sh
@@ -126,41 +126,6 @@ gha_fold --
 if [[ "$usecase" = 'soundness' ]]; then
   log "Checking all DC files for basic soundness"
 
-  #/
-  if false; then
-  # Check /all/ DC files in repo root for basic soundness
-  # shellcheck disable=SC2125
-  for dc_dir in $dc_dirs; do
-    # Creating an array
-    # declare -a check_dcs
-    check_dcs=$(find "${dc_dir}" -name "DC-*" -prinftf "%h/%f ")
-    # Remove the "./" in front of the path:
-    check_dcs=("${check_dcs//.\//}")
-
-    unsounddc=
-    for dc in "${check_dcs[@]}"; do
-      log "Checking $dc..."
-      [[ -d "$dc" ]] && unsounddc+="- $dc is a directory.\n" && continue
-      [[ ! $(grep -oP '^\s*MAIN\s*=\s*.*' "$dc") ]] && unsounddc+="- $dc does not have a valid \"MAIN\" value.\n" && continue
-      [[ $(grep -oP '^\s*MAIN\s*=\s*.*' "$dc" | wc -l) -gt 1 ]] && unsounddc+="- $dc has multiple \"MAIN\" values.\n" && continue
-      main=$(get_dc_value 'MAIN' "$dc")
-      dir_prefix=$(dirname "$dc")
-      dir="xml"
-      [[ $(echo "$main" | grep -oP '\.adoc$') ]] && dir="adoc"
-      [[ ! -f "$dir_prefix/$dir/$main" ]] && unsounddc+="- The \"MAIN\" file referenced in $dc does not exist.\n"
-    done
-  done
-
-  if [[ -n "$unsounddc" ]]; then
-    fail "The following DC file(s) from the repository are not sound:\n$unsounddc\n"
-  else
-    succeed "All DC files are sound."
-  fi
-
-  fi  #---
-
-
-  fi
 
 # USE CASE 2
 elif [[ "$usecase" = 'list-validate' ]]; then

--- a/select-dcs.sh
+++ b/select-dcs.sh
@@ -88,6 +88,8 @@ while [[ $1 ]]; do
       ;;
     ignore-files=*)
       ignore_files=$(echo "$1" | cut -f2- -d'=')
+      # Replace all newlines with space
+      ignore_files="${ignore_files//\\n/ }"
       shift
       ;;
     --)

--- a/select-dcs.sh
+++ b/select-dcs.sh
@@ -126,15 +126,19 @@ gha_fold --
 if [[ "$usecase" = 'soundness' ]]; then
   log "Checking all DC files for basic soundness"
 
+  #/
+  if false; then
   # Check /all/ DC files in repo root for basic soundness
   # shellcheck disable=SC2125
   for dc_dir in $dc_dirs; do
-    check_dcs="$dc_dir/DC-*"
+    # Creating an array
+    # declare -a check_dcs
+    check_dcs=$(find "${dc_dir}" -name "DC-*" -prinftf "%h/%f ")
+    # Remove the "./" in front of the path:
+    check_dcs=("${check_dcs//.\//}")
 
     unsounddc=
-    for dc in $check_dcs; do
-      # Remove any "./" from "DC", but keep "templates/DC-bla" intact
-      dc=${dc#*./}
+    for dc in "${check_dcs[@]}"; do
       log "Checking $dc..."
       [[ -d "$dc" ]] && unsounddc+="- $dc is a directory.\n" && continue
       [[ ! $(grep -oP '^\s*MAIN\s*=\s*.*' "$dc") ]] && unsounddc+="- $dc does not have a valid \"MAIN\" value.\n" && continue
@@ -153,6 +157,10 @@ if [[ "$usecase" = 'soundness' ]]; then
     succeed "All DC files are sound."
   fi
 
+  fi  #---
+
+
+  fi
 
 # USE CASE 2
 elif [[ "$usecase" = 'list-validate' ]]; then

--- a/select-dcs.sh
+++ b/select-dcs.sh
@@ -106,7 +106,10 @@ done
 log + "  mode=$usecase"
 log + "  mergeruns=$mergeruns"
 log + "  original_org=$original_org"
-log + "  ignore_files=$ignore_files"
+# log + "  ignore_files=$ignore_files"
+for f in $ignore_files; do
+  log + "  ignored file=$f"
+done
 
 
 dc_list=''


### PR DESCRIPTION
Currently, the `gha-select-dcs` has two bugs:

* It cannot ignore DC files. It _always_ finds _all_ DC files in every directory.
* The soundness of DC files doesn't take into account the new `SRC_DIR` variable from DAPS 4.0.